### PR TITLE
QT5 translation fails and new symbols for Electricity

### DIFF
--- a/Electricity/light_exterior_ceiling.svg
+++ b/Electricity/light_exterior_ceiling.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="light_encased.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">light_encased_roof</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.8"
+     inkscape:cx="146.77083"
+     inkscape:cy="87.604167"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1212"
+     inkscape:window-height="868"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>light_encased_roof</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:description>Exterior encased light bulb</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:0.350001;stroke-linecap:butt;stroke-linejoin:miter"
+         cx="257.16833"
+         cy="265.15033"
+         r="2"
+         id="circle146"
+         sodipodi:insensitive="true" />
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:0.350001;stroke-linecap:butt;stroke-linejoin:miter"
+         cx="257.16833"
+         cy="265.15033"
+         r="4"
+         id="circle148-6"
+         inkscape:label="circle148-6"
+         sodipodi:insensitive="true" />
+      <rect
+         style="display:inline;fill:none;stroke:#000000"
+         id="rect1"
+         width="29.427084"
+         height="29.383139"
+         x="150.16113"
+         y="72.827965"
+         transform="matrix(0.28222223,0,0,0.28222223,210.63703,240.45037)" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/light_exterior_wall.svg
+++ b/Electricity/light_exterior_wall.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="light_exterior_wall.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">light_exterior_wall</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.6"
+     inkscape:cx="155.05208"
+     inkscape:cy="41.5625"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1361"
+     inkscape:window-height="843"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:lockguides="true"
+     showguides="true">
+    <sodipodi:guide
+       position="138.54167,119.71949"
+       orientation="0,-1"
+       id="guide1"
+       inkscape:locked="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:description>Exterior wall light bulb</dc:description>
+        <dc:title>light_exterior_wall</dc:title>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <path
+         id="path1"
+         style="display:inline;fill:#000000;stroke:#000000;stroke-width:0.350001;stroke-linecap:butt;stroke-linejoin:miter"
+         inkscape:label="circle148-6"
+         d="m 250.3358,255.85117 a 4,4 0 0 1 4,-4 4,4 0 0 1 4,4" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 248.8358,255.67617 h 11"
+         id="path136-7"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:none;fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 250.44671,251.79088 7.77818,7.77818"
+         id="path136-7-3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:none;fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 250.44671,259.56906 7.77818,-7.77818"
+         id="path136-7-6"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.340215;stroke-dasharray:none"
+         id="path3"
+         sodipodi:type="arc"
+         sodipodi:cx="-254.31517"
+         sodipodi:cy="-255.52858"
+         sodipodi:rx="3.8334424"
+         sodipodi:ry="3.6810167"
+         sodipodi:start="0.82273483"
+         sodipodi:end="2.3335966"
+         sodipodi:arc-type="slice"
+         d="m -251.70759,-252.83036 a 3.8334424,3.6810167 0 0 1 -5.25629,-0.0372 l 2.64871,-2.66102 z"
+         transform="scale(-1)" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/light_interior_ceiling.svg
+++ b/Electricity/light_interior_ceiling.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="light_interior_ceiling.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">light</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.1209093"
+     inkscape:cx="161.82597"
+     inkscape:cy="85.134055"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1404"
+     inkscape:window-height="966"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>light</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:description>Interior light bulb</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         cx="256.97488"
+         cy="263.5"
+         r="4"
+         id="circle148" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         d="M 256.97489,269 V 258"
+         id="path136-7"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 251.47489,263.5 h 11"
+         id="path136-7-3"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/light_interior_wall.svg
+++ b/Electricity/light_interior_wall.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="light_interior_wall.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">light_interior_wall</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.6"
+     inkscape:cx="155.05208"
+     inkscape:cy="41.5625"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1361"
+     inkscape:window-height="843"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:lockguides="true"
+     showguides="true">
+    <sodipodi:guide
+       position="138.54167,119.71949"
+       orientation="0,-1"
+       id="guide1"
+       inkscape:locked="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:description>Interior wall light bulb</dc:description>
+        <dc:title>light_interior_wall</dc:title>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <path
+         id="path1"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.350001;stroke-linecap:butt;stroke-linejoin:miter"
+         inkscape:label="circle148-6"
+         d="m 250.3358,255.85117 a 4,4 0 0 1 4,-4 4,4 0 0 1 4,4" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 248.8358,255.67617 h 11"
+         id="path136-7"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:none;fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 250.44671,251.79088 7.77818,7.77818"
+         id="path136-7-3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:none;fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 250.44671,259.56906 7.77818,-7.77818"
+         id="path136-7-6"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.340215;stroke-dasharray:none"
+         id="path3"
+         sodipodi:type="arc"
+         sodipodi:cx="-254.31517"
+         sodipodi:cy="-255.52858"
+         sodipodi:rx="3.8334424"
+         sodipodi:ry="3.6810167"
+         sodipodi:start="0.82273483"
+         sodipodi:end="2.3335966"
+         sodipodi:arc-type="slice"
+         d="m -251.70759,-252.83036 a 3.8334424,3.6810167 0 0 1 -5.25629,-0.0372 l 2.64871,-2.66102 z"
+         transform="scale(-1)" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/socket_exterior_10A.svg
+++ b/Electricity/socket_exterior_10A.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="socket_exterior_10A.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">socket_exterior_10A</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="10.425153"
+     inkscape:cx="161.5324"
+     inkscape:cy="76.593597"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1310"
+     inkscape:window-height="854"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:description>Exterior 10A socket</dc:description>
+        <dc:title>socket_exterior_10A</dc:title>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <path
+         id="circle148"
+         style="fill:#000000;stroke:#000000;stroke-width:0.342916;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 253.12659,264.63204 a 3.8354419,4.004472 0 0 1 -0.15598,-1.13036 3.8354419,4.004472 0 0 1 3.83544,-4.00448 3.8354419,4.004472 0 0 1 3.83544,4.00448 v 0 a 3.8354419,4.004472 0 0 1 -0.15597,1.13036" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.34986668;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 256.97489,264.62888 v -7.75776"
+         id="path136-7"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.34986668;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 252.79988,259.49993 h 8.01234"
+         id="path136-7-3"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:0.32000001;stroke-linecap:round;stroke-dasharray:none"
+         id="rect1"
+         width="8.0123405"
+         height="7.7579799"
+         x="252.79988"
+         y="256.87112" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/socket_interior_10A.svg
+++ b/Electricity/socket_interior_10A.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="socket_interior_10A.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">socket_interior_10A</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.1209093"
+     inkscape:cx="161.82597"
+     inkscape:cy="85.134055"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1404"
+     inkscape:window-height="966"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:description>Interior 10A socket</dc:description>
+        <dc:title>socket_interior_10A</dc:title>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <path
+         id="circle148"
+         style="fill:#000000;stroke:#000000;stroke-width:0.342916;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 253.12659,264.63204 a 3.8354419,4.004472 0 0 1 -0.15598,-1.13036 3.8354419,4.004472 0 0 1 3.83544,-4.00448 3.8354419,4.004472 0 0 1 3.83544,4.00448 v 0 a 3.8354419,4.004472 0 0 1 -0.15597,1.13036" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.34986668;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 256.97489,264.62888 v -7.75776"
+         id="path136-7"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.34986668;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 252.79988,259.49993 h 8.01234"
+         id="path136-7-3"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/socket_interior_25A.svg
+++ b/Electricity/socket_interior_25A.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="socket_interior_25A.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">socket_exterior_25A</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="10.425153"
+     inkscape:cx="158.84658"
+     inkscape:cy="69.879068"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1310"
+     inkscape:window-height="854"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:description>Exterior 25A socket</dc:description>
+        <dc:title>socket_exterior_25A</dc:title>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <path
+         id="circle148"
+         style="fill:none;stroke:#000000;stroke-width:0.342916;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 253.29811,264.63204 a 3.8354419,4.004472 0 0 1 -0.15598,-1.13036 3.8354419,4.004472 0 0 1 3.83544,-4.00448 3.8354419,4.004472 0 0 1 3.83544,4.00448 v 0 a 3.8354419,4.004472 0 0 1 -0.15597,1.13036" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 256.97757,264.62888 v -7.75776"
+         id="path136-7"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 252.9714,259.49993 h 8.01234"
+         id="path136-7-3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 252.9714,258.78547 h 8.01234"
+         id="path136-7-3-9"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.337067;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 253.26413,264.50362 h 7.42689"
+         id="path136-7-3-2"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/switch_commutator.svg
+++ b/Electricity/switch_commutator.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="switch_commutator.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">switch_commutator</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.6"
+     inkscape:cx="136.92708"
+     inkscape:cy="52.708333"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1361"
+     inkscape:window-height="843"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:lockguides="true"
+     showguides="true">
+    <sodipodi:guide
+       position="138.54167,119.71949"
+       orientation="0,-1"
+       id="guide1"
+       inkscape:locked="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:title>switch_commutator</dc:title>
+        <dc:description>Commutator switch</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         cx="252.98019"
+         cy="254.45422"
+         r="1.0999398"
+         id="circle146" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 248.91197,250.35378 3.40015,3.40015"
+         id="path142-9"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 248.91197,250.35378 0.69736,-0.69736"
+         id="path3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 257.14316,258.64683 -3.40015,-3.40015"
+         id="path142-9-5"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 257.14316,258.64683 -0.69736,0.69736"
+         id="path3-6"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/switch_double.svg
+++ b/Electricity/switch_double.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="switch_double.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">switch_double</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.6"
+     inkscape:cx="136.92708"
+     inkscape:cy="36.041667"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1361"
+     inkscape:window-height="843"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:lockguides="true"
+     showguides="true">
+    <sodipodi:guide
+       position="138.54167,119.71949"
+       orientation="0,-1"
+       id="guide1"
+       inkscape:locked="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:title>switch_double</dc:title>
+        <dc:description>Double switch</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         cx="252.98019"
+         cy="254.45422"
+         r="1.0999398"
+         id="circle146" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 248.91197,250.35378 3.40015,3.40015"
+         id="path142-9"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 248.91197,250.35378 0.69736,-0.69736"
+         id="path3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 249.73975,251.1143 0.69736,-0.69736"
+         id="path3-3"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/Electricity/switch_simple.svg
+++ b/Electricity/switch_simple.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="85mm"
+   height="54mm"
+   id="svg3010"
+   version="1.1"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   sodipodi:docname="switch_simple.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">switch_simple</title>
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.5999999"
+     inkscape:cx="159.73959"
+     inkscape:cy="43.281251"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g3273_EU"
+     showgrid="false"
+     inkscape:window-width="1550"
+     inkscape:window-height="914"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:lockguides="true"
+     showguides="true">
+    <sodipodi:guide
+       position="138.54167,119.71949"
+       orientation="0,-1"
+       id="guide1"
+       inkscape:locked="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3014">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:title>switch_simple</dc:title>
+        <dc:description>Simple switch</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3273_EU"
+       transform="matrix(3.543307,0,0,3.543307,-746.35168,-851.98948)"
+       inkscape:label="#g3273">
+      <circle
+         style="fill:none;stroke:#000000;stroke-width:0.34986668;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         cx="263.09811"
+         cy="256.40546"
+         r="1.0999398"
+         id="circle146" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.34986668;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 259.02989,252.30501 3.40015,3.40015"
+         id="path142-9"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.349867;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none"
+         d="m 259.02989,252.30501 0.69736,-0.69736"
+         id="path3"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/SymbolsLibrary.FCMacro
+++ b/SymbolsLibrary.FCMacro
@@ -54,10 +54,23 @@ from PySide import QtGui, QtCore, QtSvg
 param = FreeCAD.ParamGet('User parameter:Plugins/symbols_library')
 s = param.GetString('destination')
 
+# Copied from Mod/Tux/NavigationIndicatorGui.py
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+
+    def translate(context, text):
+        "convenience function for Qt 4 translator"
+        return QtGui.QApplication.translate(context, text, None, _encoding)
+except AttributeError:
+    def translate(context, text):
+        "convenience function for Qt 5 translator"
+        return QtGui.QApplication.translate(context, text, None)
+
 if s:
     LIBRARYPATH = s
 else:
-    folderDialog = QtGui.QFileDialog.getExistingDirectory(None,QtGui.QApplication.translate("SymbolsLibrary", "Location of your existing Symbols library", None, QtGui.QApplication.UnicodeUTF8))
+    folderDialog = QtGui.QFileDialog.getExistingDirectory(None,translate("SymbolsLibrary", "Location of your existing Symbols library"))
+
     param.SetString('destination',folderDialog)
     LIBRARYPATH = param.GetString('destination')
 


### PR DESCRIPTION
This PR fixes the call to `QtGui.QApplication.translate` in QT5 for which the encoding parameter has been removed.
It also adds a small set of symbols related to electricity (sockets, interrupters and lights)